### PR TITLE
Notes:

### DIFF
--- a/CScan/App.config
+++ b/CScan/App.config
@@ -2,7 +2,7 @@
 
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
   </startup>
 
   <appSettings>

--- a/CScan/Authenticode.cs
+++ b/CScan/Authenticode.cs
@@ -12,9 +12,12 @@ namespace CScan
         public static bool IsSigned(string fileName, bool strict = false)
         {
             List<Signer> signers = new List<Signer>();
-            WinTrustVerify.WinTrust.Verify(fileName, out signers);
+            //WinTrustVerify.WinTrust.Verify(fileName, out signers);
 
-            return signers.Count > 0; // Might need to do more verification here.
+            return true;
+            // Crashes in an odd spot. For now, we'll always return true. Just so project builds.
+            // NOTE: WILL NEED TO BE DEBUGGED AND FIXED.
+            //return signers.Count > 0; // Might need to do more verification here.
         }
     }
 }

--- a/CScan/CScan.csproj
+++ b/CScan/CScan.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CScan</RootNamespace>
     <AssemblyName>Certly Scan</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <HighEntropyVA>True</HighEntropyVA>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
@@ -36,22 +36,26 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <Optimize>true</Optimize>
+    <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
+    <DebugType>none</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>
+    </DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup />
   <PropertyGroup>
@@ -70,6 +74,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>
@@ -93,21 +98,21 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <PlatformTarget>x86</PlatformTarget>
     <OutputPath>bin\x86\Debug\</OutputPath>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <PlatformTarget>x86</PlatformTarget>
     <OutputPath>bin\x86\Release\</OutputPath>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualBasic" />
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
-    <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Management" />
     <Reference Include="System.ServiceProcess" />

--- a/CScan/FodyWeavers.xml
+++ b/CScan/FodyWeavers.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Weavers>
   <Costura />
 </Weavers>

--- a/CScan/Main.Designer.cs
+++ b/CScan/Main.Designer.cs
@@ -42,7 +42,9 @@
             this.advancedToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.allowUnsafeOperationsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.panel1 = new System.Windows.Forms.Panel();
             this.menuStrip1.SuspendLayout();
+            this.panel1.SuspendLayout();
             this.SuspendLayout();
             // 
             // Scan
@@ -69,12 +71,15 @@
             // 
             // statusText
             // 
+            this.statusText.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.statusText.DetectUrls = false;
+            this.statusText.Dock = System.Windows.Forms.DockStyle.Fill;
             this.statusText.HideSelection = false;
-            this.statusText.Location = new System.Drawing.Point(168, 24);
+            this.statusText.Location = new System.Drawing.Point(1, 1);
             this.statusText.Name = "statusText";
             this.statusText.ReadOnly = true;
-            this.statusText.Size = new System.Drawing.Size(404, 237);
+            this.statusText.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.ForcedVertical;
+            this.statusText.Size = new System.Drawing.Size(402, 223);
             this.statusText.TabIndex = 4;
             this.statusText.Text = "";
             // 
@@ -153,13 +158,23 @@
             this.contextMenuStrip1.Name = "contextMenuStrip1";
             this.contextMenuStrip1.Size = new System.Drawing.Size(61, 4);
             // 
+            // panel1
+            // 
+            this.panel1.BackColor = System.Drawing.Color.Gray;
+            this.panel1.Controls.Add(this.statusText);
+            this.panel1.Location = new System.Drawing.Point(168, 24);
+            this.panel1.Name = "panel1";
+            this.panel1.Padding = new System.Windows.Forms.Padding(1);
+            this.panel1.Size = new System.Drawing.Size(404, 225);
+            this.panel1.TabIndex = 7;
+            // 
             // Main
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(584, 261);
+            this.Controls.Add(this.panel1);
             this.Controls.Add(this.enableJson);
-            this.Controls.Add(this.statusText);
             this.Controls.Add(this.Fix);
             this.Controls.Add(this.Scan);
             this.Controls.Add(this.menuStrip1);
@@ -173,6 +188,7 @@
             this.Text = "CScan";
             this.menuStrip1.ResumeLayout(false);
             this.menuStrip1.PerformLayout();
+            this.panel1.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -192,6 +208,7 @@
         private System.Windows.Forms.ToolStripMenuItem exitToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem scanToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem enableFileEnumerationToolStripMenuItem;
+        private System.Windows.Forms.Panel panel1;
     }
 }
 

--- a/CScan/Scanner.cs
+++ b/CScan/Scanner.cs
@@ -30,7 +30,7 @@ namespace CScan
             "Services",
             "Drivers",
             "Disks",
-            "Signatures",
+            //"Signatures",
             "Programs",
             "Files"
         };
@@ -42,7 +42,7 @@ namespace CScan
             InitializeComponents();
         }
 
-        public void Scan(ref RichTextBox status, Config config)
+        public void Scan(Config config) //(ref RichTextBox status, Config config)
         {
             var report = new Report();
 
@@ -53,7 +53,7 @@ namespace CScan
                 if (componentName == "Files" && !config.EnableFiles)
                     continue;
 
-                status.Text = status.Text + "Running " + componentName + "..." + Environment.NewLine;
+                Status="Running " + componentName + "..." + Environment.NewLine;
 
                 var watch = Stopwatch.StartNew();
 
@@ -67,7 +67,7 @@ namespace CScan
             if (!config.EnableJson)
                 Process.Start("notepad.exe", path);
 
-            status.Text = status.Text + "Success!";
+            Status = "Success!";
         }
 
         protected void InitializeComponents()
@@ -81,5 +81,33 @@ namespace CScan
                 initializedComponents.Add(initializedComponent);
             }
         }
+
+        #region Status Update Subscription
+        // This could be moved into the Main class, or this could be called as "new Scanner()."
+        // Each have their problems. So here we are going to create an event handler and allow Main
+        // to subscribe to that. In which, the statusText will be updated.
+
+        private string _status;
+
+        //Create event handle
+        public event System.EventHandler StatusChanged;
+
+        // Notify subscribers that the status changed
+        protected virtual void OnStatusChanged()
+        { if (StatusChanged != null) StatusChanged((object)Status.ToString(), EventArgs.Empty); }
+
+        public string Status
+        {
+            get
+            { return _status; }
+
+            set
+            {
+                _status = value;
+                OnStatusChanged();
+            }
+        }
+
+        #endregion
     }
 }

--- a/CScan/packages.config
+++ b/CScan/packages.config
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <packages>
-  <package id="Costura.Fody" version="2.0.0-beta0018" targetFramework="net461" developmentDependency="true" />
-  <package id="Fody" version="1.29.3" targetFramework="net461" developmentDependency="true" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
+  <package id="Costura.Fody" version="2.0.0-beta0018" targetFramework="net46" developmentDependency="true" />
+  <package id="Fody" version="1.29.3" targetFramework="net46" developmentDependency="true" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
- Currently targeted for 4.6.2 .Net. Should be 3.5 or 4.0. Then, no need to worry if end-user has .Net, as it comes with Windows Vista and is pushed through Windows Updates. But some people may not have newer than 4.0. --Changed to 4.6.0 for now. 4.0 is missing features we are using. We can fix later.

- Debug configuration was set to optimize. Only Release config should have this. Was unable to see error messages. Adjusted.

- Added UpdateStatus callback methods and Event Handler.

- Scanner is now called in it's own thread. We subscribe Main() to the UpdateStatus. Then safely call to textbox through invoke. (UI no longer locks up)

- Set Authenticode to always return signed for now until we can debug this. This way project will at least build.